### PR TITLE
Rename driver folder option

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository provides a single Python script `setup_manager.py` to copy iRaci
 ## Features
 
 - Import setups from a ZIP archive or from another folder, or skip importing entirely.
-- Customisable team, personal and season folder names.
+- Customisable team, personal, setup supplier and season folder names.
 - Remembers the last configuration in `user_config.json`.
 - Works with any Setup supplier: select the folder or ZIP they provide.
 - Can run silently when executed with the `--silent` argument or when
@@ -65,7 +65,7 @@ running on a server), the script also falls back to silent mode.
 1. Run `python setup_manager.py` to open the interface.
 2. Select your **iRacing Setups Folder** and choose whether to import from a
    ZIP file or from another folder.
-3. Fill in the team, personal, driver and season folders as desired.
+3. Fill in the team, personal, setup supplier and season folders as desired.
 4. Optionally enable backup or logging and choose where these files will be
    stored.
 5. Press **Run** to perform the import and sync. The settings are saved for the
@@ -95,8 +95,8 @@ options. Each setting is saved in `user_config.json` for the next run.
   (default `Example Team`).
 * **Personal Folder Name (source)** – your personal folder that provides
   files (default `My Personal Folder`).
-* **Driver Folder Name (inside team folder)** – subfolder for your driver
-  name (default `Example Driver`).
+* **Setup Supplier Name (inside team folder)** – subfolder for your setup
+  supplier name (default `Example Supplier`).
 * **Season Folder (inside driver folder)** – season subfolder
   (default `Example Season`).
 * **Sync Source Folder (copy from)** – name of the source folder in each car

--- a/setup_manager.py
+++ b/setup_manager.py
@@ -23,8 +23,8 @@ MAP_FILE = "custom_car_mapping.json"
 VERSION = "1.0.0"
 # Location of the latest script version for the self-update feature
 UPDATE_URL = (
-    "https://raw.githubusercontent.com/yourusername/"
-    "iRacing-Setups-Sync/main/setup_manager.py"
+    "https://raw.githubusercontent.com/MahoNishizumi/"
+    "nishizumi-setups-sync/main/setup_manager.py"
 )
 
 # ---------------------- Config Handling ----------------------
@@ -35,7 +35,7 @@ DEFAULT_CONFIG = {
     "source_folder": "",
     "team_folder": "Example Team",
     "personal_folder": "My Personal Folder",
-    "driver_folder": "Example Driver",
+    "driver_folder": "Example Supplier",
     "season_folder": "Example Season",
     "sync_source": "Example Source",
     "sync_destination": "Example Destination",
@@ -868,7 +868,7 @@ def main():
     driver_frame = ttk.Frame(scrollable)
     ttk.Label(
         driver_frame,
-        text="Driver Folder Name (inside team folder)",
+        text="Setup Supplier Name (inside team folder)",
     ).pack()
     driver_entry = ttk.Entry(driver_frame, width=40)
     driver_entry.insert(0, cfg.get("driver_folder", ""))
@@ -907,12 +907,13 @@ def main():
     ttk.Button(backup_frame, text="Browse", command=browse_backup).pack()
 
     log_var = tk.IntVar(value=1 if cfg.get("enable_logging", False) else 0)
-    ttk.Checkbutton(
+    log_var_chk = ttk.Checkbutton(
         scrollable,
         text="Enable logging",
         variable=log_var,
         command=lambda: toggle_log_fields(),
-    ).pack()
+    )
+    log_var_chk.pack()
 
     log_frame = ttk.Frame(scrollable)
     ttk.Label(log_frame, text="Log File").pack()
@@ -1089,13 +1090,13 @@ def main():
 
     def toggle_backup_fields():
         if backup_var.get():
-            backup_frame.pack()
+            backup_frame.pack(after=backup_var_chk)
         else:
             backup_frame.pack_forget()
 
     def toggle_log_fields():
         if log_var.get():
-            log_frame.pack()
+            log_frame.pack(after=log_var_chk)
         else:
             log_frame.pack_forget()
 


### PR DESCRIPTION
## Summary
- rename "Driver Folder Name" option to "Setup Supplier Name"
- adjust default config and README references
- fix update URL to point to MahoNishizumi repo

## Testing
- `python -m py_compile setup_manager.py`
- `flake8 setup_manager.py | head` *(fails: line length)*

------
https://chatgpt.com/codex/tasks/task_e_68410134c958832a8b98e7e92666ee31