### PR TITLE
Fix driver count spinbox

### DIFF
--- a/nishizumi_setups_sync.py
+++ b/nishizumi_setups_sync.py
@@ -885,6 +885,7 @@ def main():
             self.driver_check = QtWidgets.QCheckBox("Manually write drivers names")
             self.driver_check.setChecked(self.cfg.get("use_driver_folders", False))
             d_layout.addWidget(self.driver_check)
+            self.driver_check.toggled.connect(self.update_garage_fields)
             d_layout.addWidget(QtWidgets.QLabel("Number of drivers"))
             self.driver_count_spin = QtWidgets.QSpinBox()
             self.driver_count_spin.setRange(0, 10)


### PR DESCRIPTION
## Summary
- enable driver count spinbox when "Manually write drivers names" is toggled

## Testing
- `python -m py_compile nishizumi_setups_sync.py`

------
https://chatgpt.com/codex/tasks/task_e_6841142f4394832aa9d26e7221c9a01d