### PR TITLE
Fix config path for Windows EXE

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,9 @@ Season Folder:        2025S1
 
 When running without `--silent`, the script shows a window where you can
 configure how setups are imported. The window resizes automatically to fit all
-options. Each setting is saved in `user_config.json` for the next run.
+options. Each setting is saved in `user_config.json` for the next run. When
+packaged as an executable, this file sits alongside the `.exe` so your
+preferences persist between launches.
 
 Only the **iRacing Setups Folder** and **Backup Folder** fields expect full
 paths. Every other folder input should contain just a folder name that will be
@@ -179,7 +181,9 @@ performed on a Windows machine:
    ```
 
 The resulting `nishizumi_setups_sync.exe` will appear in the `dist` folder. You can
-share or run this file directly without needing Python.
+share or run this file directly without needing Python. The program stores its
+configuration in `user_config.json` next to the executable, so ensure the folder
+containing the `.exe` allows write access.
 
 ## Future Ideas
 

--- a/nishizumi_setups_sync.py
+++ b/nishizumi_setups_sync.py
@@ -19,8 +19,17 @@ except ModuleNotFoundError:  # pragma: no cover - handle missing dependency
 import re
 from datetime import datetime
 
-CONFIG_FILE = "user_config.json"
-MAP_FILE = "custom_car_mapping.json"
+# Store configuration files next to the script or executable. When bundled
+# with PyInstaller using ``--onefile`` the temporary extraction directory would
+# be removed on exit, so we resolve paths relative to the running file instead
+# of the current working directory.
+if getattr(sys, "frozen", False):
+    _BASE_DIR = os.path.dirname(sys.executable)
+else:
+    _BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+
+CONFIG_FILE = os.path.join(_BASE_DIR, "user_config.json")
+MAP_FILE = os.path.join(_BASE_DIR, "custom_car_mapping.json")
 VERSION = "1.0.0"
 # Location of the latest script version for the self-update feature
 UPDATE_URL = (


### PR DESCRIPTION
## Summary
- persist `user_config.json` and mapping files next to the executable
- mention persistence behaviour in README

## Testing
- `python -m py_compile nishizumi_setups_sync.py`
- `python nishizumi_setups_sync.py --help | head -n 20`
- `python nishizumi_setups_sync.py --update | head -n 5`

------
https://chatgpt.com/codex/tasks/task_e_684115b6e1d4832ab47f1b3bb94eb5e5