### PR TITLE
Update README note about EXE

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,15 @@ share or run this file directly without needing Python. The program stores its
 configuration in `user_config.json` next to the executable, so ensure the folder
 containing the `.exe` allows write access.
 
+> **Warning**
+> At the moment packaging the script as an executable does not work correctly.
+> The configuration is not saved persistently when running the `.exe`, so for now
+> you should run the script with Python instead:
+>
+> ```bash
+> python nishizumi_setups_sync.py
+> ```
+
 ## Future Ideas
 
 Some potential improvements for later versions:


### PR DESCRIPTION
## Summary
- document that the executable build currently doesn't save settings

## Testing
- `python -m py_compile nishizumi_setups_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68411ab216a0832a9d2cb472548fd270