### PR TITLE
Rename folder labels and add usage warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository provides a single Python script `nishizumi_setups_sync.py` to co
 ## Features
 
 - Import setups from a ZIP archive or from another folder, or skip importing entirely.
-- Customisable team, personal, setup supplier and season folder names.
+- Customisable team, personal, setup supplier folder and season folder names.
 - Remembers the last configuration in `user_config.json`.
 - Works with any Setup supplier: select the folder or ZIP they provide.
 - Can run silently when executed with the `--silent` argument or, when
@@ -74,9 +74,10 @@ running on a server), the script also falls back to silent mode.
 1. Run `python nishizumi_setups_sync.py` to open the interface.
 2. Select your **iRacing Setups Folder path** using the folder browser and choose
    whether to import from a ZIP file or from another folder.
-3. Fill in the team, personal, setup supplier and season folders with *folder
-   names only*. The script creates or uses folders with these names inside every
-   car directory.
+3. Fill in the team, personal, setup supplier folder and season folder names
+   with *folder names only*. These folders must exist inside your iRacing setups
+   folder and will be created automatically if they do not. The script uses
+   these folders inside every car directory.
 4. Optionally enable backup or logging and browse to the **Backup Folder** and
    log file locations.
 5. Press **Run** to perform the import and sync. The settings are saved for the
@@ -90,7 +91,7 @@ iRacing Setups Folder: C:\iRacing\setups
 Backup Folder:        D:\SetupsBackup
 Team Folder Name:     MyTeam
 Personal Folder Name: DriverOne
-Season Folder:        2025S1
+Season Folder Name:   2025S1
 ```
 
 ## Interface Guide
@@ -103,7 +104,9 @@ preferences persist between launches.
 
 Only the **iRacing Setups Folder** and **Backup Folder** fields expect full
 paths. Every other folder input should contain just a folder name that will be
-created or monitored inside each car directory.
+created or monitored inside each car directory. These folders must be located
+inside your iRacing setups folder and will be created automatically if they do
+not exist.
 
 * **iRacing Setups Folder** – root folder that stores all car setup folders.
   Select the full path using the folder browser.
@@ -124,10 +127,10 @@ created or monitored inside each car directory.
   (default `Example Team`). Use only the folder name; do not include a path.
 * **Personal Folder Name (source)** – your personal folder that provides
   files (default `My Personal Folder`). Name only, no path.
-* **Setup Supplier Name (inside team folder)** – subfolder for your setup
-  supplier name (default `Example Supplier`). Invalid characters and
+* **Setup Supplier Folder Name (inside team folder)** – subfolder for your
+  setup supplier name (default `Example Supplier`). Invalid characters and
   trailing spaces are automatically removed. Name only.
-* **Season Folder (inside driver folder)** – season subfolder
+* **Season Folder Name (inside supplier folder)** – season subfolder
   (default `Example Season`). Name only.
 * **Sync Source Folder (copy from)** – name of the source folder in each car
   directory (default `Example Source`). Name only.

--- a/nishizumi_setups_sync.py
+++ b/nishizumi_setups_sync.py
@@ -780,6 +780,12 @@ def main():
             layout = QtWidgets.QVBoxLayout(container)
 
             layout.addWidget(QtWidgets.QLabel("Fill the options below and press Run."))
+            layout.addWidget(
+                QtWidgets.QLabel(
+                    "All folder names must be inside your iRacing setups folder."
+                    " Missing folders will be created automatically."
+                )
+            )
 
             self.iracing_entry = self._add_browse(
                 layout,
@@ -823,12 +829,12 @@ def main():
             )
             self.driver_entry = self._add_entry(
                 layout,
-                "Setup Supplier Name (inside team folder)",
+                "Setup Supplier Folder Name (inside team folder)",
                 self.cfg.get("driver_folder"),
             )
             self.season_entry = self._add_entry(
                 layout,
-                "Season Folder (inside driver folder)",
+                "Season Folder Name (inside supplier folder)",
                 self.cfg.get("season_folder"),
             )
 


### PR DESCRIPTION
## Summary
- rename Setup Supplier Name to Setup Supplier Folder Name
- rename Season Folder to Season Folder Name
- warn that folder names must be inside iRacing setups folder and will be created automatically

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68411f78c6e0832a871ef563e2600edb